### PR TITLE
Send data in batch format

### DIFF
--- a/alooma-extension/src/main/java/com/mparticle/ext/alooma/AloomaExtension.java
+++ b/alooma-extension/src/main/java/com/mparticle/ext/alooma/AloomaExtension.java
@@ -23,13 +23,11 @@ public class AloomaExtension extends MessageProcessor {
 
     //this name will show up in the mParticle UI
     public static final String NAME = "Alooma";
-
     //The Alooma input token
     public static final String SETTING_TOKEN = "token";
     //The Alooma hostname <hostname>.alooma.io
     public static final String SETTING_HOSTNAME = "hostname";
 
-    String hostname;
     String token;
     Client client = JerseyClientBuilder.createClient()
             .register(ObjectMapper.class)
@@ -112,86 +110,17 @@ public class AloomaExtension extends MessageProcessor {
      */
     @Override
     public EventProcessingResponse processEventProcessingRequest(EventProcessingRequest request) throws IOException {
-        //do some setup, then call super. if you don't call super, you'll effectively short circuit
-        //the whole thing, which isn't really fun for anyone.
-        Account account = request.getAccount();
-        hostname = account.getStringSetting(SETTING_HOSTNAME, true, null);
-        token = account.getStringSetting(SETTING_TOKEN, true, null);
-        webTarget = client.target("https://"+hostname+".alooma.io");
+        if (request.getEvents().size() > 0) {
+            Account account = request.getAccount();
+            String hostname = account.getStringSetting(SETTING_HOSTNAME, true, null);
+            token = account.getStringSetting(SETTING_TOKEN, true, null);
+            webTarget = client.target("https://" + hostname + ".alooma.io");
+            //don't forward credentials/API keys
+            request.setAccount(null);
+            sendEvent(request);
+        }
 
-        return super.processEventProcessingRequest(request);
-    }
-
-    @Override
-    public void processProductActionEvent(ProductActionEvent event) throws IOException {
-        sendEvent(event);
-        super.processProductActionEvent(event);
-    }
-
-    @Override
-    public void processApplicationStateTransitionEvent(ApplicationStateTransitionEvent event) throws IOException {
-        sendEvent(event);
-        super.processApplicationStateTransitionEvent(event);
-    }
-
-    @Override
-    public void processCustomEvent(CustomEvent event) throws IOException {
-        sendEvent(event);
-        super.processCustomEvent(event);
-    }
-
-    @Override
-    public void processErrorEvent(ErrorEvent event) throws IOException {
-        sendEvent(event);
-        super. processErrorEvent(event);
-    }
-
-    @Override
-    public void processPrivacySettingChangeEvent(PrivacySettingChangeEvent event) throws IOException {
-        sendEvent(event);
-        super.processPrivacySettingChangeEvent(event);
-    }
-
-    @Override
-    public void processPushMessageReceiptEvent(PushMessageReceiptEvent event) throws IOException {
-        sendEvent(event);
-        super.processPushMessageReceiptEvent(event);
-    }
-
-    @Override
-    public void processPushSubscriptionEvent(PushSubscriptionEvent event) throws IOException {
-        sendEvent(event);
-        super.processPushSubscriptionEvent(event);
-    }
-
-    @Override
-    public void processScreenViewEvent(ScreenViewEvent event) throws IOException {
-        sendEvent(event);
-        super.processScreenViewEvent(event);
-    }
-
-    @Override
-    public void processSessionStartEvent(SessionStartEvent event) throws IOException {
-        sendEvent(event);
-        super.processSessionStartEvent(event);
-    }
-
-    @Override
-    public void processSessionEndEvent(SessionEndEvent event) throws IOException {
-        sendEvent(event);
-        super.processSessionEndEvent(event);
-    }
-
-    @Override
-    public void processUserAttributeChangeEvent(UserAttributeChangeEvent event) throws IOException {
-        sendEvent(event);
-        super.processUserAttributeChangeEvent(event);
-    }
-
-    @Override
-    public void processUserIdentityChangeEvent(UserIdentityChangeEvent event) throws IOException {
-        sendEvent(event);
-        super.processUserIdentityChangeEvent(event);
+        return new EventProcessingResponse();
     }
 
     @Override
@@ -204,9 +133,9 @@ public class AloomaExtension extends MessageProcessor {
         return super.processAudienceSubscriptionRequest(request);
     }
 
-    private void sendEvent(Event event) throws IOException{
+    private void sendEvent(EventProcessingRequest eventRequest) throws IOException{
         Response response = webTarget.path("rest/"+token).request()
                 .accept(MediaType.APPLICATION_JSON_TYPE)
-                .post(Entity.json(event));
+                .post(Entity.json(eventRequest));
     }
 }


### PR DESCRIPTION
This updates the AloomaExtension class to upload data in a single JSON batch, the reasoning is:

- sending data in this format will more closely resemble mParticle's documented JSON models, rather than firehose-specific implementation objects
- should be more efficient to send as a single upload, rather than a bunch of uploads with duplicative data
- this also remove account information from the upload